### PR TITLE
Removed potentially confusing animals

### DIFF
--- a/lib/animals.txt
+++ b/lib/animals.txt
@@ -75,8 +75,6 @@ gnat
 gnu
 goat
 goose
-goldfinch
-goldfish
 gorilla
 goshawk
 grasshopper
@@ -163,7 +161,6 @@ rhinoceros
 rook
 ruff
 salamander
-salmon
 sandpiper
 sardine
 scorpion


### PR DESCRIPTION
There are some animals that have colour-like names.  These are
potentially confusing because the name parts are no longer unique to a
position.  For example...
-  red-goldfish
-  gold-redwing

It becomes slightly easier to remember names if each part (or part of
a part) can only exist in one position.
-  "Salmon" is arguably a colour.
-  "Goldfinch" and "Goldfish" both start with colours.
